### PR TITLE
[RTM] Fix the table header field labels

### DIFF
--- a/src/Resources/contao/modules/ModuleListing.php
+++ b/src/Resources/contao/modules/ModuleListing.php
@@ -272,7 +272,16 @@ class ModuleListing extends \Module
 
 			$class = '';
 			$sort = 'asc';
-			$strField = \strlen($label = $GLOBALS['TL_DCA'][$this->list_table]['fields'][$arrFields[$i]]['label'][0]) ? $label : $arrFields[$i];
+			
+			// Field label
+			if (isset($GLOBALS['TL_DCA'][$this->list_table]['fields'][$arrFields[$i]]['label']))
+			{
+				$strField = is_array($GLOBALS['TL_DCA'][$this->list_table]['fields'][$arrFields[$i]]['label']) ? $GLOBALS['TL_DCA'][$this->list_table]['fields'][$arrFields[$i]]['label'][0] : $GLOBALS['TL_DCA'][$this->list_table]['fields'][$arrFields[$i]]['label'];
+			}
+			else
+			{
+				$strField = $arrFields[$i];
+			}
 
 			// Add a CSS class to the order_by column
 			if ($order_by == $arrFields[$i])
@@ -286,7 +295,7 @@ class ModuleListing extends \Module
 				'link' => $strField,
 				'href' => (ampersand($strUrl) . $strVarConnector . 'order_by=' . $arrFields[$i]) . '&amp;sort=' . $sort,
 				'title' => \StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['list_orderBy'], $strField)),
-				'class' => $class . (($i == 0) ? ' col_first' : '') //. ((($i + 1) == count($arrFields)) ? ' col_last' : '')
+				'class' => $class . (($i == 0) ? ' col_first' : '') . ((($i + 1) == count($arrFields)) ? ' col_last' : '')
 			);
 		}
 

--- a/src/Resources/contao/modules/ModuleListing.php
+++ b/src/Resources/contao/modules/ModuleListing.php
@@ -272,15 +272,12 @@ class ModuleListing extends \Module
 
 			$class = '';
 			$sort = 'asc';
-			
+			$strField = $arrFields[$i];
+
 			// Field label
 			if (isset($GLOBALS['TL_DCA'][$this->list_table]['fields'][$arrFields[$i]]['label']))
 			{
 				$strField = is_array($GLOBALS['TL_DCA'][$this->list_table]['fields'][$arrFields[$i]]['label']) ? $GLOBALS['TL_DCA'][$this->list_table]['fields'][$arrFields[$i]]['label'][0] : $GLOBALS['TL_DCA'][$this->list_table]['fields'][$arrFields[$i]]['label'];
-			}
-			else
-			{
-				$strField = $arrFields[$i];
 			}
 
 			// Add a CSS class to the order_by column


### PR DESCRIPTION
In case that the language variable does not consist of an array, the field labels in the table header were not output correctly. This PR fixes the problem.

Furthermore, the CSS class `col_last` was not shown because it was commented out in the source code.
  
(applies to Contao 3.5 as well)